### PR TITLE
Add standalone Codex port for zero-downtime-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Two scouts map the deploy in parallel — one reads the repository, one looks at
 
 [Read more →](./plugins/zero-downtime-deploy/README.md)
 
+Codex users can install the standalone
+[`zero-downtime-deploy` skill](./codex-skills/zero-downtime-deploy) without the Claude plugin runtime.
+
 ---
 
 ### vibe-audit

--- a/codex-skills/zero-downtime-deploy/SKILL.md
+++ b/codex-skills/zero-downtime-deploy/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: zero-downtime-deploy
+description: "Set up, harden, or audit deployment so releases do not interrupt service: start the new version beside the old one, prove readiness, switch traffic, drain the old version, and rehearse rollback. Use when the user asks 'настрой деплой', 'деплой без даунтайма', 'чтобы при деплое не падало', 'сделай откат', 'проверь наш деплой', 'zero downtime', 'blue-green', 'rolling deploy', or reports 502/504 during releases, logouts on deploy, failed rollback, or concurrent deploys colliding. Also use to assess whether a database migration is safe while the app runs. Keep the project's existing platform; do not introduce Kubernetes, Terraform, or a new cloud provider. Do not use merely to execute an already-configured deploy, debug a past incident, fix failing CI, or write an unrelated Dockerfile."
+---
+
+# Zero-Downtime Deploy — Release Without Interrupting Service
+
+You make releases invisible to users: the new version runs beside the old one, proves it is ready,
+takes traffic, and the old one drains instead of dying mid-request. If the new version can't prove
+itself, users stay on the old one and nothing changes for them.
+
+## The one rule that overrides everything
+
+**Keep the platform the project already runs on.** The strategy is whatever native mechanism that
+platform already has for holding the old version alive until the new one is ready. Never add
+Kubernetes, Terraform, a new cloud provider, a separate monitoring platform, or GitOps machinery
+to reach zero downtime. If the platform already switches traffic itself, do not build a second
+switch beside it.
+
+Never add lint, typecheck, a second health endpoint, a staging environment, extra monitoring, or a
+README when the chosen traffic switch already works without them. Scope creep is the main way this
+skill fails.
+
+## What "zero downtime" has to mean before you start
+
+"No noticeable interruption" is not a target you can verify. Pin it down in Phase A, in the user's
+own terms: no 5xx above the normal background during a release, no user logged out, no request
+longer than N seconds killed, rollback back on the old version within N minutes.
+
+If the honest answer is that zero downtime is not achievable here — one instance, no spare memory
+for a second one, a fixed port, a single-writer process, sessions in process memory — **say it in
+Phase A**, before any file changes. The honest deliverable is then a 5-15 second planned restart at
+a chosen time, not a fake blue-green on top of a single process.
+
+## Evidence — one vocabulary, one habit
+
+**Every check carries exactly one status.** There is no sixth status and no unlabelled check.
+
+| Status | Means | Where it goes |
+|---|---|---|
+| `PASS` | The command ran; its output is in the report | Verified list |
+| `FAIL` | It ran and failed — actual output, not a paraphrase | Blocks completion |
+| `SKIP(n/a)` | The project has no such thing (no Docker, no workers) | Nowhere; it does not apply |
+| `SKIP(no access)` | Cannot run here — name exactly what is missing | Human checklist |
+| `NOT-RUN` | Nobody ran it — the default for anything you wrote but never executed | Human checklist |
+
+**Every claim about production names its source, inline.** Not a tag system — a habit:
+
+> «Приложение стартует юнитом app.service (живой сервер: `systemctl status app`)»
+> «Деплой описан через docker compose (репозиторий: deploy/README.md:12) — на сервере не проверял»
+
+The repository is intent; only the live system is reality. Reading a Dockerfile never becomes a fact
+about production, however plausible it looks.
+
+Rules that override everything else in this skill:
+
+- **A file you wrote is not a check you ran.** Creating `deploy.sh` proves nothing about deploying.
+- **Never write "настроено" / "работает" / "проверено" for anything that is not PASS.** An honest
+  NOT-RUN is worth more than a confident guess — the user will lean on this report during an outage.
+- If the user asks "всё готово?", answer with counts: "проверено N из M, не проверено: <список>".
+
+## Protocol
+
+### Codex coordination
+
+This standalone skill runs on Codex, not the original Claude plugin runtime. The three specialist
+roles are bundled as ordinary prompt references:
+
+- `references/roles/infra-scout.md`
+- `references/roles/live-drift-checker.md`
+- `references/roles/rollback-critic.md`
+
+Before delegating a role, read its prompt completely. When collaboration agents are available and
+the role is a concrete independent subtask, call `collaboration.spawn_agent` and include the full
+role prompt plus the project path and task-specific context. The scouts are read-only. Never
+delegate user approval, production mutation, or the final decision. If collaboration tools or slots
+are unavailable, perform the same role locally; missing agents never block the workflow.
+
+The repository and live scouts may run in parallel because both are read-only and independent. Use
+the critic only after a scheme and evidence exist. Do not spawn agents for a small repository when
+local inspection is faster.
+
+When a user decision is required, use `request_user_input` only if it is available in the current
+mode. Otherwise ask one concise question in the final response and stop. Never invent an answer to
+cross a hard gate.
+
+### Step 0 — bootstrap or audit?
+
+Decide first; the two runs produce different work.
+
+- No CI workflow, no deploy script, no health endpoint, no trace of a previous run → **bootstrap**.
+- Any of those already exist → **audit**. Do not rewrite what works. Find where downtime still leaks
+  and fix only that. Re-verify the rollback: one tested at setup time and never rehearsed since is
+  `NOT-RUN`, not "done".
+
+In an audit run, drift is the first finding, before any recommendation. Read `references/discovery.md`.
+
+### Phase A — map how traffic reaches the process today
+
+Phase A answers one question: **how does live traffic reach the process right now, and how will the
+new version replace it without cutting the requests currently in flight?**
+
+Do not compile an inventory of the stack. Language, framework, and package manager you learn on the
+way; they are not findings.
+
+Start with the repository scout. It always applies. Read
+`references/roles/infra-scout.md`, then delegate that role with the project path or execute it
+locally. Ask it to map what starts the app, what sits in front, instance count, workers and cron,
+migrations, secret sources by name only, and the available rollback path.
+
+**Add the live scout only when there is somewhere for it to go** — an ssh alias, an authenticated
+platform CLI, a read-only API. Check first; spawning an agent to report "no access" is waste. When
+there is a route, run it in parallel with the first:
+
+Read `references/roles/live-drift-checker.md`, then delegate it or execute it locally. Give it only
+known read-only routes to the live system and the repository scout's findings to compare against.
+
+No route to the live system is a normal outcome, not a failure. It changes only one thing: every
+production claim keeps "репозиторий" as its source, and the report says so plainly.
+
+On a small project you may do Phase A yourself instead of spawning anything. Agents earn their place
+when the repository is large or the two pictures need to be built independently — not by default.
+
+**Never average the two.** A disagreement between the repository and the live system is a finding of
+its own, and it comes before any recommendation:
+
+> "В репозитории деплой описан через docker compose, на сервере приложение запущено юнитом
+> app.service, правленным руками. Пока это расходится, любой скрипт деплоя из репозитория трогает
+> не то, что работает."
+
+Then pick the strategy — one decisive question, not a menu of six. It is the last section of
+`references/discovery.md`.
+
+#### HARD GATE — the deployment map, then stop
+
+Print the map and stop. **No file changes until the user says go.** "Настрой деплой" in the first
+message authorizes Phase A only; silence is not consent.
+
+The map has five parts, none of which may be filled from assumption:
+
+1. **How traffic reaches the process now** — each fact naming its source (live system / repository).
+2. **Where a release drops requests today** — one line per cause, tied to evidence: "один процесс,
+   перезапуск на месте (`systemctl restart app`, deploy.sh:12) → каждый деплой рвёт открытые запросы".
+3. **The chosen strategy and why it is the simplest that works here** — one paragraph.
+4. **Whether zero downtime is achievable at all** — see above; say it now, not after an hour.
+5. **What this run will NOT do** — everything needing credentials, DNS, payment, or a production action.
+
+Present it with the "now → after" table below, then ask: делаем / только план / стоп.
+
+If the platform is ambiguous — a Dockerfile *and* a Procfile *and* a hand-written server script —
+do not choose from file presence. Show the candidates with the evidence for each and ask the user.
+Until answered, write nothing. A wrong platform assumption invalidates every
+later step.
+
+### Phase B — change only what the chosen switch requires
+
+Touch only the files without which the chosen traffic switch does not work. For each change, name
+the failure mode it closes. No file exists for it? Do not create one "for completeness".
+
+Order of work, each with its reference:
+
+1. **Readiness** — one honest endpoint that answers "this process can serve a request". Do not let a
+   shared-dependency blink evict the whole fleet at once; handle apps that cannot serve without that
+   dependency explicitly. `references/traffic-switch.md`
+2. **Draining and shutdown** — the proxy must stop sending before the process stops accepting.
+   `references/traffic-switch.md`
+3. **The switch itself** — native platform mechanism, immutable version id (never `latest`), one
+   deploy at a time, and a reliable deployment record. Use a committed desired-state file only for
+   repository-driven deploys; otherwise use the platform's release record and capture the previous
+   exact id before switching. `references/discovery.md`
+4. **Migrations** — expand → migrate → contract, and the rollback window. `references/migrations.md`
+5. **Workers, cron, queues, sessions, caches, client bundles.** `references/workers-and-state.md`
+
+### Phase C — verify, then rehearse the rollback
+
+Run the checks the project actually has — never invent a lint or a test suite that isn't there.
+`references/verification.md` defines what counts as verified.
+
+Two checks matter more than the rest, and both are commonly faked:
+
+- **Smoke tests must address the new version directly** — its own URL, internal address, or routing
+  header. A smoke test through the public domain before the switch is testing the *old* version and
+  is green no matter what. Read-only paths plus readiness; no invented "safe write".
+- **The rollback must be executed, not described.** See the gate below.
+
+And one number decides whether the headline claim is true at all: **measure the switch**. Run a probe
+against production during the deploy — a request every 200 ms — and count how many did not return
+200. `references/verification.md` has the script. Without that count, "zero downtime" is an opinion;
+with it, the report says «во время переключения 1500 запросов, ошибок 0». Where the probe cannot run,
+it is `SKIP(no access)` and the claim is downgraded accordingly, never dropped silently.
+
+#### HARD GATE — rollback drill
+
+A rollback script that has never run is not a rollback. Before reporting anything as ready, execute
+it once end to end in the safest place available (staging, preview, a second slot — never production
+without explicit approval):
+
+1. Deploy the current version; note its exact identifier.
+2. Deploy the same code again as a new release id — users see nothing.
+3. Run the rollback command back to the previous id.
+4. Measure: seconds until traffic is fully back on the previous version, and how many requests
+   errored in between.
+
+Report the measured number. "Откат занимает 40 секунд, проверено" is something the user can act on
+at 3am; "откат настроен" is not. No safe place to run it? Do **not** run it — mark `SKIP(no access)`,
+write the exact command the user must run and what success looks like.
+
+Then state the **rollback window** in one sentence: how many releases back the app can go without
+breaking on the current database schema. After a contract migration that window is zero and the only
+way out is forward — say so explicitly.
+
+Finally, if the scheme is anything beyond a single managed-platform service — two slots, workers,
+migrations, long-lived connections — spawn the critic. The one who built it is the worst judge of it:
+
+Read `references/roles/rollback-critic.md`, then delegate it or execute it locally. Pass the scheme,
+all evidence statuses, and unresolved production assumptions. Ask for concrete failure scenarios,
+not a general review.
+
+Fold surviving objections into the report as open risks. Do not argue them away.
+
+### Phase D — report
+
+The report is for a product person. Structure:
+
+1. The "now → after" table (below) — what changes for a person during a release.
+2. The measured switch: requests sent during the deploy and how many failed. If it was not measured,
+   say so in the same place — that is where the reader looks for it.
+3. What was actually run, with commands and output — PASS / FAIL.
+4. What was not run — SKIP / NOT-RUN, each with the one command the user runs to close it.
+5. Claims that rest only on repository files, never confirmed against the live system. Missing this
+   list makes the report dishonest.
+6. Secrets needed and where to create them — never the values, never in chat.
+7. The routine deploy, and the exact rollback procedure as a copy-pasteable command.
+8. Open risks the critic raised.
+
+## Production mutation gate
+
+Never run a production deployment, switch live traffic, change DNS, create or change secrets, run a
+production migration, purge old assets, or delete the previous release without explicit approval for
+that exact action. Before asking, show: what environment changes, the exact commands, the expected
+traffic and data transitions, the rollback path, the observation window, and every claim that was
+never confirmed against the live system.
+
+No credentials or permissions? Continue with repository work and safe local checks, list the blocked
+commands with who must run them — and never call the result "готово". No access means no claim.
+
+## Anti-patterns — the ways this work is faked
+
+- **Readiness that blindly pings a shared dependency.** The dependency blinks, every instance
+  reports not-ready at once, and the balancer may drop the whole fleet. Prefer per-process readiness.
+  If the app truly cannot serve any useful request without that dependency, design and verify the
+  fleet-wide failure behaviour instead of hiding it behind an unconditional `SELECT 1`.
+- **Smoke tests through the public domain** before the switch. Always green, always meaningless.
+- **An invented "safe write" test.** Either it writes to production or it isn't a write. Use a marked
+  test entity that gets cleaned up, or report the write path as not verified.
+- **"Immediately return traffic to the previous version"** without checking that the old code still
+  runs on the current schema, config, and queue contents. Sometimes the honest move is roll-forward.
+- **A rollback that exists only as a script.** See the drill gate.
+- **Trusting the repository as a picture of production.** It is intent, not reality.
+- **Two health endpoints because a checklist said so.** Readiness is required; liveness only when the
+  platform genuinely restarts on it — a bad liveness probe causes restart storms.
+- **"One artifact through all environments"** is the right default, not an absolute: when config is
+  baked at build time, one artifact physically cannot serve two environments. Say which case it is.
+
+## References
+
+Load only what the current step needs.
+
+| When | Read |
+|---|---|
+| Phase A, and every audit run | `references/discovery.md` |
+| Readiness, draining, keep-alive, shutdown order | `references/traffic-switch.md` |
+| Any migration in the release | `references/migrations.md` |
+| Workers, cron, queues, sessions, caches, front/back order, long interruptible work | `references/workers-and-state.md` |
+| Phase C and the final report | `references/verification.md` |
+| Once the platform is established | `references/platform-playbooks.md` |
+
+<!-- report-format-contract -->
+### Output format: the "now → after" table
+
+The report is read by a product person, not an engineer. Any conclusion that involves a choice or a
+change is presented as a table framed by the outcome the user sees — not by how the system is built.
+
+**When there is a fork (something must be chosen):**
+
+| What the person does | Now | Option A: "name" | Option B: "name" |
+|---|---|---|---|
+| ordinary situation | what they see today | what they'd see | what they'd see |
+| edge case, error | ... | ... | ... |
+
+Below the table, a "Why" block: one line per option (what it wins, what it costs). Then one line:
+"Recommend X, because …".
+
+**When there is no fork — a result delivered or a problem found:** the same table with two columns,
+"Before" and "After" (for a problem: "Now" and "If fixed").
+
+Rules for filling it in:
+
+- Rows are real user situations, never system components. "Открыл сайт в момент выкладки", not
+  "nginx upstream reload".
+- Cells say what the person will see, concretely and with numbers: "страница грузится 2 секунды
+  дольше" or "502 на 8 секунд", not "деградация".
+- The "Now" column is mandatory — without a baseline the options have nothing to compare against. If
+  the thing doesn't exist yet, write "doesn't exist".
+- Include at least one edge-case row: the new version fails to start, a migration is already applied,
+  the deploy is triggered twice. That is usually where the options actually diverge.
+- 2-4 rows, 2-3 options. More means the thinking isn't finished and the choice is being dumped on the
+  reader.
+- Name options by meaning ("старая версия ждёт" / "переключаем сразу"), never "Option 1/2".
+
+No fork and no change means no table: one line saying what you're doing and why. Technical detail
+(files, line numbers, config) belongs under the conclusion as evidence, never instead of it. Write
+the table in the language the user is speaking.
+
+## Key principles
+
+- **The old version keeps serving until the new one proves itself.** Everything else is detail.
+- **Minimal change.** The smallest set of files that makes the chosen switch work.
+- **Honesty over completeness.** A short report where every line is verified beats a long one with
+  invented checkmarks.
+- **Stop at the gates.** Phase A gate, production mutation gate, rollback drill gate. They are the
+  reason this skill is safe to run on a live project.
+- **Match the user's language.** Ilya writes in Russian — report in Russian.

--- a/codex-skills/zero-downtime-deploy/agents/openai.yaml
+++ b/codex-skills/zero-downtime-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Zero-Downtime Deploy"
+  short_description: "Safe deploys with measured rollback"
+  default_prompt: "Use $zero-downtime-deploy to audit this release path and design a verified zero-downtime rollout with rollback."

--- a/codex-skills/zero-downtime-deploy/references/discovery.md
+++ b/codex-skills/zero-downtime-deploy/references/discovery.md
@@ -1,0 +1,136 @@
+# Discovery and drift
+
+Phase A answers one question: **how does live traffic reach the process right now, and how will the
+new version replace it without cutting the requests in flight?**
+
+Everything below serves that question. Nothing here is a form to fill in.
+
+## The five decisive questions
+
+Answers to these change the strategy. Answers to anything else do not.
+
+1. **Who holds the public port, and can it move traffic between two versions without dropping open
+   connections?** nginx, Caddy, a cloud load balancer, the platform's own router, or nothing at all
+   (the process is exposed directly — the hardest case).
+2. **How many instances of the app run at once, and can the host hold two versions simultaneously?**
+   Check spare memory, CPU, free ports, database connection limit, license limits. One instance on a
+   box with no headroom means zero downtime is not achievable without changing something the user
+   has not agreed to change.
+3. **How does the process restart today, and what happens to requests in flight?** In-place restart,
+   process manager reload, container replace, platform deploy.
+4. **Are there background workers and cron jobs, and do they live with the web process or apart?**
+5. **Who applies migrations, and at what moment relative to the traffic switch?** From CI, from a
+   deploy script, or on application boot from every instance.
+
+Two more that are cheap to answer and expensive to miss: where sessions live (process memory or a
+shared store), and whether a built frontend is served with hashed asset filenames.
+
+## Where to look
+
+Repository side — `infra-scout` covers this:
+
+- CI config (`.github/workflows/`, `.gitlab-ci.yml`), any `deploy*.sh`, `Makefile` deploy targets
+- `Dockerfile`, `docker-compose*.yml`, `Procfile`, `fly.toml`, `render.yaml`, `app.json`, `vercel.json`
+- process manager files: systemd units, `ecosystem.config.js`, supervisor configs
+- proxy config committed in the repo (`nginx/`, `Caddyfile`)
+- migration tooling and where it is invoked from
+- health routes already in the code
+- how secrets reach the app (`.env.example`, CI secret names — never values)
+
+Live side — `live-drift-checker` covers this, read-only:
+
+| Question | Typical read-only command |
+|---|---|
+| What starts the app | `systemctl status <unit>`, `pm2 list`, `docker ps` |
+| Which version is live | platform CLI, deployed image digest, `git rev-parse HEAD` on the server |
+| Proxy actually in force | `nginx -T`, the platform's router config |
+| Instance count | `docker ps`, `pm2 list`, platform CLI |
+| Managed platform state | `fly status`, `render services list`, `gcloud run revisions list`, `aws ecs describe-services` |
+
+Never run anything that writes. If a command needs credentials that are not present, the fact simply
+has no live source — say so; never fill the gap with a guess from the repository.
+
+## Drift is a finding, not a nuisance
+
+The repository is intent. The live system is reality. When they disagree, report the disagreement
+before any recommendation, and never average them:
+
+> "В репозитории описан деплой через docker compose, на сервере приложение запущено юнитом
+> app.service, менялся 2024-11-03. Пока это расходится, любой скрипт деплоя из репозитория трогает
+> не то, что работает."
+
+Typical drift worth naming explicitly: a proxy config edited by hand on the server, a systemd unit
+with flags no file mentions, a cron job absent from git, an environment variable the running process
+has and the repository never mentions, a deployed version that is not any commit on the main branch.
+
+Fixing drift silently is the fastest way to take a working system down. Show it, then ask.
+
+## Re-entry: the skill has run here before
+
+Signs of a previous run: a CI deploy workflow, `deploy.sh` / `rollback.sh`, a health route, a
+`DEPLOYMENT.md` written by this skill.
+
+1. Read what the previous run claimed — that is the **declared** state.
+2. Compare against the live system — that is the **actual** state.
+3. The goal of a re-run is to close `NOT-RUN` items and drift, not to rebuild.
+
+Do not create a second workflow, a second health endpoint, or a parallel deploy script "just in
+case". If declared and actual agree and nothing new appeared, say so and propose only the delta:
+new workers, new migrations, a new endpoint since last time.
+
+## No access to the live system
+
+This is common and it is fine. What changes is what you may claim:
+
+- Do the repository work and the safe local checks.
+- Every conclusion resting only on repository files is collected into one list, "предположения,
+  которые я не смог проверить", at the end of the report.
+- List the one-time actions the user must perform outside the repository, as commands they can run.
+- Never invent a staging environment, and never describe the pipeline as proven in production.
+
+## Picking the strategy — one decisive question
+
+**Is there something in front of the app that can move traffic between two versions without dropping
+open connections, and is there room to run both at once?**
+
+| Answer | What that means |
+|---|---|
+| The platform switches traffic itself (managed PaaS, orchestrator with rolling updates) | Use its native mechanism. Do not build a second switch beside it. Your work is readiness, draining, migrations, and a rollback you can prove. |
+| There is a proxy you control and the host can hold two versions | Two slots behind the proxy: start the new one, prove it, repoint, drain the old one. |
+| There is a proxy, but no room for two versions | Free capacity first, or accept a short planned restart. Say which, in Phase A. |
+| Nothing in front — the process owns the public port | Zero downtime is unreachable without adding something in front. That is a real change: put it to the user as a fork, don't do it silently. |
+
+Canary only when the platform already supports it and the user actually needs it.
+
+### The invariants — true on every platform
+
+- The new version takes no production traffic until readiness passes.
+- The old version is not stopped until traffic has moved off it *and* drained.
+- The production version has an immutable id — commit SHA, image digest, release id. Never `latest`.
+- One production deploy at a time; a new push must not interrupt one that is mid-switch.
+- **The deployed version has a durable authoritative record.** For repository-driven desired state,
+  this can be a committed file. For managed platforms, use the platform release/revision record and
+  persist the exact stable id in the deploy run. Record it *before* the deploy — never infer "the
+  previous entry in the list", which can reorder. Git describes intent; the platform record still
+  decides what is actually live.
+- The artifact that was verified is the artifact that ships.
+
+That last one is the right default, not a law: when configuration is baked in at build time
+(`NEXT_PUBLIC_*`, `import.meta.env`, compiled asset URLs), one artifact physically cannot serve two
+environments. Then say the build is per-environment and keep source and toolchain provably identical
+instead of pretending to promote one artifact.
+
+### Capacity, before committing to two slots
+
+Two versions alive at once means, briefly, double the footprint: memory and CPU headroom, a free port
+or container slot, and database connections (two versions × pool size under the server limit). Any
+per-instance lock or single-writer constraint breaks the plan outright. Better an honest planned
+restart than a blue-green that exhausts the connection pool mid-switch.
+
+### One deploy at a time
+
+A CI-level lock protects the CI job only — not a manual deploy, a console deploy, or a migration run
+by hand at the same moment. Lock the production *environment* where the platform allows it, and make
+the deploy idempotent so a retry of the same version is a no-op rather than a second switch. On
+GitHub Actions use a concurrency group per environment with `cancel-in-progress: false`, so a new
+push queues behind a deploy that is already switching traffic instead of killing it halfway.

--- a/codex-skills/zero-downtime-deploy/references/migrations.md
+++ b/codex-skills/zero-downtime-deploy/references/migrations.md
@@ -1,0 +1,74 @@
+# Database migrations during a zero-downtime release
+
+During the release both versions of the code are alive at the same time. The schema has to be
+compatible with both — not just with the new one.
+
+## Expand → migrate → contract
+
+1. **Expand.** Add new tables, columns, indexes. Nothing removed, nothing renamed. New columns are
+   nullable or have a default.
+2. **Release code that works against both shapes** — writes to both if needed, reads the old shape as
+   a fallback.
+3. **Backfill data separately**, in batches, outside the deploy.
+4. **Switch the code to the new shape** in a later release.
+5. **Contract** — drop the old columns — in a release *after* that.
+
+Contract is never in the same release as expand. This is the whole point of the pattern, and it is
+the part that gets collapsed under time pressure.
+
+## The rollback window
+
+The consequence nobody writes down: **rolling the app back only works if the previous version of the
+code still runs against the current schema.**
+
+State it explicitly, once per release, in one sentence: *how many releases back can we go without
+breaking on the current schema?*
+
+- After expand only → the window is at least one release. Rollback is a button.
+- After contract → the window is zero. Rollback is an incident, and the only way out is forward or a
+  restore from backup.
+
+Rolling the application back must never trigger a down-migration automatically. A down-migration that
+drops a column destroys the data written since the deploy. If the old code cannot run on the current
+schema, the answer is roll-forward, a feature flag, or a manual plan — never an automatic reverse
+migration.
+
+## Operations that need a separate plan, never a casual deploy
+
+- `DROP COLUMN`, `DROP TABLE`
+- renaming a column or table that is in use (it is two releases: add, dual-write, migrate, drop)
+- adding a `NOT NULL` column with no default and no backfill
+- changing a column type in a way that rewrites the table
+- any long, blocking migration
+- an irreversible data transformation
+
+If a safe automatic migration cannot be produced, **stop before the production deploy** and write out
+the manual plan. That is a valid, complete outcome for this skill.
+
+## Locks: the migration that took 10 ms on the dev database
+
+On a real table with traffic, the danger is not the migration's own duration — it is the lock queue.
+In PostgreSQL, a statement waiting for a lock blocks every query that arrives behind it, and the
+table stalls for everyone.
+
+- Set `lock_timeout` and `statement_timeout` on the migration connection, so a migration that cannot
+  get its lock fails fast instead of freezing the table.
+- Create indexes concurrently where the engine supports it (`CREATE INDEX CONCURRENTLY` in Postgres —
+  and know that it cannot run inside a transaction and leaves an invalid index behind if it fails).
+- Do not assume "adding an index" is part of the harmless expand phase. It depends on the engine, the
+  table size, and the traffic.
+
+## Run migrations exactly once
+
+Migrating on application boot means every instance starts migrating simultaneously during a rolling
+release. Some tools lock and it merely serializes; some do not and it corrupts.
+
+Run migrations as one step — from CI or a deploy step — before the new version takes traffic, and
+make that step non-concurrent with any other deploy. If the project migrates on boot today, say so in
+Phase A; it is a downtime cause in its own right.
+
+## Order relative to the traffic switch
+
+The safe default: schema first (expand only, compatible with the old code), then the new version,
+then traffic. A schema change that the currently-running old version cannot tolerate must never land
+before the code that needs it.

--- a/codex-skills/zero-downtime-deploy/references/platform-playbooks.md
+++ b/codex-skills/zero-downtime-deploy/references/platform-playbooks.md
@@ -1,0 +1,82 @@
+# Platform playbooks
+
+Load this **after** the production platform is established, and only the section that applies.
+
+Two rules for using this file. Every number here must be read from the project's actual configuration
+before it is used — a playbook that contradicts the live system loses. And only the non-obvious is
+written down: generic Docker and nginx knowledge is not repeated here.
+
+## Docker Swarm (`docker stack deploy`)
+
+Swarm has everything needed natively; the failure mode is leaving the defaults in place.
+
+- **`update_config.order` is the whole game.** The default `stop-first` kills the old task before
+  starting the new one — on a single-replica service that is guaranteed downtime on every deploy.
+  Use `start-first`. It only works if the service can have two tasks alive at once, so a service
+  publishing a fixed host port (`mode: host`) must move to an overlay/ingress port or accept the gap.
+- **Without a `healthcheck`, `start-first` is a lie.** Swarm considers a task ready the moment the
+  container starts, so traffic reaches a process that is still booting. Define `healthcheck` on the
+  service (or `HEALTHCHECK` in the image) pointing at readiness — that is what makes rolling updates
+  and `failure_action: rollback` mean anything.
+- `failure_action: rollback` plus `rollback_config` gives automatic revert to the previous service
+  spec — but only fires on a failure Swarm can see, which is why the healthcheck is a prerequisite.
+- `update_config.monitor` is how long a new task must stay healthy before the update continues. It is
+  the bake window for the rollout; the default is short.
+- `docker service rollback <service>` returns to the previous spec — the manual rollback, no config
+  edit needed. It reverts the *spec*, not the database.
+- `stop_grace_period` must exceed the app's own shutdown budget, and the app's force-exit timer must
+  be shorter than the grace period, so the process exits on its own rather than being killed.
+- `docker service update --detach` returns immediately — the deploy script has then proven nothing.
+  Wait for convergence (`docker service ps`, or poll until the desired count is running and healthy)
+  before calling the deploy done. A `sleep` is not convergence.
+- Run migrations as a one-shot container from a **migrator image tagged with the same release**, so
+  the migration code provably matches the version being deployed, and it runs exactly once rather
+  than from every starting replica.
+
+## Single VM: process manager + nginx
+
+- **Two slots on two ports.** nginx upstream points at one; deploy starts the other, waits for
+  readiness on its port directly, then repoints and reloads.
+- Reload nginx, never restart: reload lets old workers finish their connections.
+- After the reload, give the old process a drain window longer than nginx's `keepalive_timeout`
+  before stopping it, and have it close idle keep-alive connections.
+- A release directory per commit SHA with a `current` symlink makes rollback a symlink swap plus a
+  reload — keep the last few directories or the rollback has nowhere to go.
+- With systemd, check `KillSignal` and `TimeoutStopSec` against what the app expects; a unit that
+  kills at 10s makes a 30s graceful shutdown fiction.
+
+## Docker Compose on a single host
+
+- `docker compose up -d` on a changed image recreates the container — stop-then-start, not a
+  zero-downtime replacement, unless something in front holds traffic. Start the new container beside
+  the old one, wait for its health, repoint the proxy, then stop the old one.
+- Use the image digest or a SHA tag as the production identifier; `latest` makes "which version is
+  live" unanswerable and rollback ambiguous.
+- Compose healthchecks gate `depends_on` and restarts — they are not the proxy's view of readiness.
+  The proxy needs its own check.
+- `stop_grace_period` must exceed the app's drain.
+- Before trusting a rollback, confirm the previous image still exists on the host or in the registry;
+  aggressive pruning is what makes rollbacks fail at the worst moment.
+
+## Managed platforms (Render, Railway, Fly, Cloud Run, ECS, Vercel)
+
+The platform already keeps the old version serving until the new one is healthy. Do not rebuild that.
+
+- **Point the platform's health check at readiness** and confirm a failing new version genuinely
+  blocks the switch. Left at its default, many platforms switch anyway.
+- Version identity and rollback are the platform's own — release id, revision, task definition.
+  Record the current one before deploying and roll back to that exact id.
+- Pre-switch smoke tests are only meaningful if the candidate URL runs against the production data
+  path. Where it does not, say the smoke test proves the build, not the release.
+- Scale-to-zero changes the picture: a cold start is part of the user's latency during a release.
+
+## GitHub Actions as the pipeline
+
+- Concurrency group per environment with `cancel-in-progress: false` on the production job.
+- Build once: the deploy job uses the image built and verified earlier in the same run, by digest.
+- Secrets from environment secrets or short-lived OIDC — never in the workflow file, never echoed to
+  logs, never a build argument that ends up in an image layer.
+- Record the previous version id as a job output before the switch, so a rollback job can target it
+  explicitly instead of guessing.
+- A human confirmation step (`workflow_dispatch` with a typed confirmation, or a required reviewer on
+  the production environment) is a cheap and effective gate for a small team.

--- a/codex-skills/zero-downtime-deploy/references/roles/infra-scout.md
+++ b/codex-skills/zero-downtime-deploy/references/roles/infra-scout.md
@@ -1,0 +1,24 @@
+# Infra scout role
+
+Act as the read-only repository scout for a zero-downtime deployment review.
+
+Answer one question: according to repository files, how is traffic supposed to reach the process,
+and what happens to requests in flight when a release replaces it? Repository files describe
+intent, never production reality.
+
+Inspect only relevant sources: CI deploy jobs, deploy scripts, Docker/Compose/Procfile/platform
+manifests, process-manager and proxy configs, health routes, migrations, workers, queues, cron,
+session storage, built assets, and secret names or sources. Never expose secret values.
+
+Return fewer than 60 lines with:
+
+1. Entry point/public port, with `file:line` evidence.
+2. Start/restart mechanism and configured instance count.
+3. Current switch behaviour and treatment of in-flight requests.
+4. Workers, cron, migrations, health routes, sessions, assets, and secret sources.
+5. Rollback mechanism the repository appears to support.
+6. Ambiguous competing deploy paths without choosing between them.
+7. Downtime causes visible in the repository.
+
+Every claim must cite `file:line`. Run read-only commands only. Do not edit files, deploy, restart,
+reload, migrate, or infer live state. If evidence is missing, omit the claim or label it unknown.

--- a/codex-skills/zero-downtime-deploy/references/roles/live-drift-checker.md
+++ b/codex-skills/zero-downtime-deploy/references/roles/live-drift-checker.md
@@ -1,0 +1,21 @@
+# Live drift checker role
+
+Act as the strictly read-only live-system scout. Establish what is actually running and compare it
+with repository intent.
+
+Use only routes already available: a known SSH alias, an authenticated platform CLI, or a read-only
+API. Do not hunt for credentials. Never restart, reload, deploy, scale, edit config, rotate secrets,
+run migrations, or print secret values. If the only useful command mutates state, report the fact as
+unknown and name the command a human would need to run.
+
+Check, where access permits:
+
+- process manager and instance count;
+- exact live version, revision, or image digest;
+- proxy/router and health-check configuration in force;
+- keep-alive, drain, deregistration, and termination timeouts;
+- cron/systemd timers and platform rollout state.
+
+Return fewer than 60 lines with: access routes tried; live facts with the exact command and short
+output excerpt; drift against repository findings; and facts not checked with the reason. A live
+fact requires a command that ran in this session. Repository files never prove production state.

--- a/codex-skills/zero-downtime-deploy/references/roles/rollback-critic.md
+++ b/codex-skills/zero-downtime-deploy/references/roles/rollback-critic.md
@@ -1,0 +1,23 @@
+# Rollback critic role
+
+Act as an adversarial, read-only reviewer of a completed deployment scheme. Attack two claims:
+
+1. Users will not notice a release.
+2. The rollback will work when needed.
+
+Use the supplied scheme, evidence statuses, repository evidence, live configuration, and unresolved
+assumptions. Test concrete scenarios: readiness and draining races; keep-alive versus grace periods;
+smoke tests accidentally hitting the old version; missing immutable rollback identity; old code
+against the current schema/config/queue payloads; partial rollout or migration success; duplicate
+cron/jobs; in-memory sessions; shared-cache shape changes; and deleted old frontend chunks.
+
+Return fewer than 60 lines with:
+
+- one-line verdict and biggest hole;
+- scenarios where users still see errors, each with mechanism, evidence, and severity;
+- scenarios where rollback fails, each with mechanism, evidence, and severity;
+- claims stronger than their evidence status allows;
+- areas that remain unproven because access or evidence is missing.
+
+Do not modify files or systems. Do not manufacture findings. Every objection needs a concrete
+failure scenario and evidence; rank user-visible harm first.

--- a/codex-skills/zero-downtime-deploy/references/traffic-switch.md
+++ b/codex-skills/zero-downtime-deploy/references/traffic-switch.md
@@ -1,0 +1,92 @@
+# Readiness, draining, and shutdown
+
+This is where "we did zero downtime" and "there are still 502s in the log during releases" part ways.
+
+## Readiness
+
+Readiness answers one question: **can this process serve a request right now?** Code loaded, port
+open, pools warm, migrations it needs already applied.
+
+**Do not blindly put dependencies shared by every instance into readiness.** If every instance
+pings the same database and it blinks for three seconds, the entire fleet may report not-ready at
+once and a brief degradation becomes a total outage. Prefer per-process readiness and a separate
+deep-health check. If the application cannot serve any useful request without that dependency,
+state that constraint, use failure thresholds that do not flap the whole fleet, and verify the
+resulting behaviour instead of assuming either choice is safe.
+
+Liveness is a different thing: "the process is wedged, restarting will fix it". Add it only when the
+platform genuinely restarts on it and there is a detectable state that a restart actually cures. A
+careless liveness probe produces restart storms — it is not free, and it is not required for zero
+downtime.
+
+The health endpoint must be reachable by whatever checks it: not behind authentication, not behind
+the rate limiter, not behind a redirect. A balancer that gets 401 or 429 will remove a healthy
+instance. And it returns nothing sensitive — no secrets, no config dump, no stack traces; a status
+and, at most, a version id.
+
+## The old version does not stop receiving requests because you sent it a signal
+
+Removing an instance from the upstream is not instantaneous, and it does not close connections that
+are already open. Two separate races:
+
+1. **Propagation.** The balancer keeps sending for some seconds after deregistration — ALB
+   deregistration delay, Kubernetes endpoint propagation, an nginx reload that has not finished.
+2. **Keep-alive.** Connections already established stay open and carry *new* requests into a process
+   that is shutting down.
+
+So: readiness must start failing **before** the process starts shutting down, with a pause long
+enough for the proxy to notice — at least two of its health-check intervals — and the server must
+close idle keep-alive connections during the drain (send `Connection: close`).
+
+Three numbers must line up. Get them from the actual configs, not from memory:
+
+| Number | Rule |
+|---|---|
+| Proxy / balancer idle keep-alive timeout | Must be **shorter** than the app's own keep-alive timeout, or the proxy will reuse a connection the app just closed — the classic intermittent 502 |
+| Deregistration / propagation delay | The drain must be longer than this |
+| Termination grace period | Longer than propagation + the longest normal request |
+
+If the process is killed before the grace period expires, none of the above matters — check what the
+platform's timeout actually is, not what the config file wishes it were.
+
+**Until you can show that the balancer stopped sending new requests to the old process, the shutdown
+is not graceful.** "We sent SIGTERM" is not evidence.
+
+## Shutdown order
+
+1. Fail readiness; keep serving.
+2. Wait for the proxy to actually stop sending (propagation delay), closing idle keep-alive
+   connections as they fall idle.
+3. Stop accepting new connections.
+4. Stop accepting new background jobs.
+5. Let in-flight HTTP requests finish, up to a drain timeout longer than the longest normal request.
+6. Let in-flight jobs finish or return them safely to the queue.
+7. **Then** close the database pool — after the requests, never before; a pool closed early turns
+   finishing requests into errors and can leave a transaction half-applied.
+8. Exit.
+
+Handle the termination signal the platform actually sends, and make the process exit on its own
+before the platform's hard kill: **the app's own shutdown timeout must be shorter than the platform's
+grace period**, with a force-exit timer as the backstop. Budget each stage of the shutdown so the
+stages together fit inside that timeout — a drain that can outlast it is the same as no drain.
+
+## Long-lived connections
+
+- **WebSocket / SSE:** they will not drain on their own. Either the client reconnects (make sure it
+  does, with backoff) or the server closes them deliberately at the start of the drain with a code
+  the client understands as "reconnect". Otherwise the grace period expires and everyone is cut at
+  once. Give this stage its own small budget — a few hundred milliseconds is usually enough to close
+  them cleanly — and drain them *before* stopping queues and the database, so clients reconnect to a
+  live process instead of hanging on a dying one.
+- **Long requests (uploads, exports, streaming responses):** the drain timeout must exceed them, or
+  they are collateral on every release. If they can run for minutes, that is a design fact to state
+  in Phase A, not something to paper over.
+- **Multi-step flows** (a wizard, a paginated job): step one may land on the old version, step two on
+  the new. That is only safe if both versions accept the same intermediate state.
+
+## In-flight database work
+
+- Close the pool last (see above).
+- Two versions alive at once means two pools: check the connection limit.
+- A transaction interrupted by a kill rolls back — fine if the operation is idempotent and retried,
+  not fine if it was a multi-statement side-effect the caller assumes completed.

--- a/codex-skills/zero-downtime-deploy/references/verification.md
+++ b/codex-skills/zero-downtime-deploy/references/verification.md
@@ -1,0 +1,134 @@
+# What counts as verified
+
+The point of this file: make it impossible to report a deployment as ready when nothing was actually
+executed.
+
+## Only real commands
+
+Run the checks the project already has. Do not add a linter, a type checker, or a test suite in order
+to have something to run — that is a different job, and it inflates the diff of a deploy change.
+
+Report each as a row: the command, whether it applied, whether it ran, its exit code, its verdict.
+
+| Check | Command found in project | Status |
+|---|---|---|
+| install from lockfile | … | PASS / FAIL / SKIP(n/a) / SKIP(no access) / NOT-RUN |
+| lint | … | … |
+| typecheck | … | … |
+| tests | … | … |
+| production build | … | … |
+| container build | … | … |
+| CI config syntax | … | … |
+| health endpoint locally | … | … |
+
+`SKIP(n/a)` is a good outcome when the project genuinely has no such command. Inventing one is not.
+
+## Smoke tests must address the new version directly
+
+A smoke test that goes through the public domain *before* the switch is talking to the **old**
+version. It is green regardless of whether the new version is alive. This is the single easiest way
+to ship a broken release with a passing pipeline.
+
+Address the new version by its own URL, its internal address, or a routing header. Then check:
+
+- readiness on the new version
+- the main public route — including that the assets it references resolve
+- one critical read path
+- one critical write path **only** if the project already has a safe way to do it: a marked test
+  entity that gets cleaned up, a sandbox tenant, an idempotent endpoint. If it does not, report the
+  write path as not verified. Never invent a "safe write".
+- the worker starts and picks up a job, if workers are part of the release
+
+Never touch real payments, real emails, or deletions. Bound the retries and set a total timeout — the
+pipeline must fail rather than wait forever.
+
+On a managed platform where the pre-switch version is only reachable through a preview URL that
+points at a different database, say so: that smoke test does not prove the production path, and
+calling it proof is false confidence.
+
+## Measure the switch itself
+
+Everything above proves the new version works. None of it proves the switch was invisible — that is
+a separate number, and without it "zero downtime" stays an opinion.
+
+Start a simple probe before the deploy and stop it after, then report what it counted:
+
+```bash
+# before triggering the deploy
+end=$(( $(date +%s) + 300 ))
+ok=0; bad=0
+while [ "$(date +%s)" -lt "$end" ]; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://<production-url>/<cheap-route>)
+  if [ "$code" = "200" ]; then ok=$((ok+1)); else bad=$((bad+1)); echo "$(date +%T) $code"; fi
+  sleep 0.2
+done
+echo "ok=$ok failed=$bad"
+```
+
+Report the result as a sentence a person can act on: «во время переключения 1500 запросов, ошибок 0»
+or «ошибок 7, все 502 в течение 3 секунд — вот когда». A non-zero count is not a failure of the work;
+it is the honest baseline everything after this is measured against.
+
+Where this cannot run (no public route reachable from here, no permission), it is `SKIP(no access)`
+with the script handed to the user — never a claim that the switch was clean.
+
+## After the switch: a bake window
+
+Smoke tests catch a version that is dead. They do not catch a version that passes readiness and dies
+of memory pressure four minutes later under real traffic.
+
+Keep watching for a defined window (5–15 minutes is a reasonable default) with an explicit abort
+condition — error rate above the pre-deploy baseline, latency past a threshold, queue lag growing —
+and with the rollback still primed. Compare against the baseline captured *before* the deploy, not
+against nothing.
+
+## Partial failure
+
+Releases are not binary. Decide up front what happens when:
+
+- some instances updated and some did not
+- the new version is ready on one instance and failing on another
+- the migration applied but the rollout did not
+- the rollout controller hung
+- the rollback itself failed
+
+The default that keeps users safe: stop rolling forward, return the already-updated instances to the
+saved stable version, and show a human exactly what changed. Do not flip twice in the same minute —
+a rollback issued while the old version is still draining creates a second outage on top of the
+first. Pause, then decide.
+
+## The rollback drill
+
+Described in the skill's Phase C gate. What makes the drill real:
+
+- the saved identifier of the stable version still resolves — the image was not pruned, the release
+  still exists
+- the credentials and permissions to run the rollback are present
+- the old version's configuration and secrets are still valid
+- the old code still runs on the current schema (the rollback window)
+- the command actually moves traffic, and the elapsed time is measured
+
+Anything not exercised is `SKIP(no access)` or `NOT-RUN`, with the exact command written out for the
+user. "Кнопка есть, живьём не гоняли" is an acceptable answer. "Откат настроен" is not.
+
+## What each deploy should leave behind
+
+Use the logging and CI history that already exist — do not add a monitoring service for this. Each
+deploy leaves: the version id, start and finish time, health check result, smoke test result, the
+previous version id, and whether the switch succeeded or a rollback happened. That last pair is what
+makes the next rollback possible.
+
+## Shutdown behaviour is testable
+
+Rare, but worth naming: if a release has already bitten you — work lost on a restart, a job that
+resumed twice, a record left half-written — that scenario can be covered by an ordinary test that
+flips the shutdown flag and asserts what survives. Suggest it only after such a bug has actually
+happened; writing shutdown tests preemptively on a project that has never been bitten is exactly the
+over-engineering this skill refuses elsewhere.
+
+## The final report
+
+Three lists, always, in this order: **verified** (with commands and output), **not verified** (with
+the command the user runs to close each), and **claims that rest only on repository files** and were
+never confirmed against the live system. A report without the third list is dishonest, and the third
+list being long is not a failure.

--- a/codex-skills/zero-downtime-deploy/references/workers-and-state.md
+++ b/codex-skills/zero-downtime-deploy/references/workers-and-state.md
@@ -1,0 +1,106 @@
+# Workers, queues, cron, and everything that outlives the process
+
+The HTTP path is the easy half. Most of what actually breaks during a release lives outside it.
+
+## Queues: compatibility runs in both directions
+
+The schema rule applies to message payloads too, and in both directions:
+
+- During the release, the **old** worker receives messages produced by the **new** version.
+- After a rollback, the **old** worker inherits a backlog written by the new version.
+
+So the order is fixed: **teach the consumer to read the new format first, in one release; start
+producing the new format in a later one.** Deleting the old parser is a third release, after the
+backlog has drained.
+
+Also check:
+
+- **Ack / visibility timeout** must be longer than a worker restart, or a job in flight gets
+  redelivered and runs twice mid-deploy.
+- **Idempotency.** A job that can run twice must be safe to run twice — an idempotency key, or a
+  check before the side effect. Without it, "at least once" delivery plus a rolling restart equals
+  duplicate charges or duplicate emails.
+- **Retry and dead-letter behaviour** during the switch: a burst of failures caused by the deploy
+  itself should not exhaust retries and dump good jobs into the DLQ.
+
+## Cron and scheduled jobs
+
+Two versions alive at once means the schedule fires in both. A daily billing job that runs twice is
+worse than a deploy that takes 30 seconds.
+
+Mechanisms that actually work, in order of preference:
+
+1. Run scheduled jobs from one place only — a platform scheduler, or one designated instance.
+2. A lock around the job with a TTL and a token (advisory lock, Redis lock with an owner id), so a
+   crashed holder cannot block the job forever and a stale holder cannot resume as if it still owned
+   it.
+3. Disable cron on the version being retired as the first step of its shutdown.
+
+"Ensure jobs are idempotent or use locking" without naming which one is an empty instruction — pick
+the mechanism and write it down.
+
+## Work that outlives the drain window
+
+Some operations are simply longer than any sane shutdown budget: a document being parsed chunk by
+chunk, a batch job, a paid model call in a loop. Do not stretch the grace period to cover them —
+make them interruptible instead.
+
+The pattern that works, and the ordering matters:
+
+1. One dependency-free module holding a synchronous boolean: `isShuttingDown()` / `setShuttingDown()`.
+   Synchronous because it is read in a hot loop between units of work.
+2. `setShuttingDown()` is the **first** line of the shutdown handler, before draining anything else,
+   so an in-flight loop sees it as early as possible.
+3. The loop uses **commit-then-check**: finish the current unit, persist its checkpoint, *then* look
+   at the flag and bail. Checking first and bailing mid-unit loses that unit's work — and if the unit
+   costs money (a model call, a paid API), a mid-unit bail means paying for it twice on resume.
+4. What the bail leaves behind must be resumable: a checkpoint that recovery can pick up, not a
+   half-finished record that looks complete.
+
+## Don't leave the user staring at a spinner
+
+When the process goes down, whatever was "in progress" in the interface stays that way forever unless
+shutdown says otherwise. Before exiting, mark interrupted runs as failed (or as resumable) and give
+that write a moment to land — a second or two inside the shutdown budget.
+
+The rule: **shutdown must leave user-visible state consistent, not just the process dead.** A person
+who reloads after a release should see a clear error or a resumable job, never an eternal "выполняется".
+
+## Order of rollout: backend, then frontend
+
+- **Backend first, and it must keep serving the old frontend.** Only additive API changes in a
+  release; removing a field or an endpoint waits for the release after the clients stopped using it.
+- **Frontend second.** A new frontend against an old API means calls to endpoints that do not exist.
+- During any rolling release the same user's first request may hit the new version and the second the
+  old one. The API contract must tolerate that, not just "eventually converge".
+
+## Client bundles: the empty screen nobody attributes to the deploy
+
+A person has the page open. It was served by the old build. They click, the app lazy-loads a chunk —
+and it is 404, because the deploy replaced the assets.
+
+- Keep the assets of the previous builds for at least a day; publish new immutable assets *before*
+  the HTML that references them.
+- Catch chunk-load failures in the client and offer a reload instead of a blank screen.
+- Mind the HTML cache TTL and any service worker: they decide how long old clients linger.
+- A smoke test that only fetches the main route proves nothing here — it must confirm the referenced
+  JS and CSS actually resolve.
+
+## Sessions, caches, local disk
+
+- **Sessions in process memory make zero downtime impossible** — every release logs users out. Find
+  this in Phase A and say it out loud. Do not fix it by introducing Redis unless the user asked; it
+  is a fork for them to decide.
+- **Shared cache between versions.** If the new version writes a different shape under the same key,
+  the *old* version starts failing to deserialize — the deploy breaks the version that was working.
+  Rule: change the shape, change the key prefix. Never the value alone under the same key.
+- **Signing and encryption keys** must be shared by both versions during the overlap, or every
+  cookie, token, and signed URL issued by one is rejected by the other.
+- **Files on local disk** (uploads, generated exports) do not follow the app to a new container or a
+  second slot. If the app writes to local disk, that is a constraint on the strategy, not a detail.
+
+## Config and environment variables
+
+A config change shipped in the same release as code that requires it is a classic outage: the config
+lands, the old instances read it, and they were never built for it. Treat runtime config like the
+schema — additive first, and compatible with both versions during the overlap.

--- a/plugins/zero-downtime-deploy/README.md
+++ b/plugins/zero-downtime-deploy/README.md
@@ -15,6 +15,23 @@ something that was actually executed, not just written down.
 /zero-downtime-deploy "безопасно ли выкатывать эту миграцию"
 ```
 
+## Codex
+
+A standalone Codex port lives in
+[`codex-skills/zero-downtime-deploy`](../../codex-skills/zero-downtime-deploy).
+It keeps the same deployment protocol and safety gates without depending on Claude plugin agents,
+`Task(...)`, `AskUserQuestion`, or Claude model aliases.
+
+Install it globally by asking Codex:
+
+```text
+Install this skill globally:
+https://github.com/izmailovilya/ilia-izmailov-plugins/tree/main/codex-skills/zero-downtime-deploy
+```
+
+The Codex port bundles the three specialist roles as prompt references. Codex can delegate them to
+collaboration agents when available and executes the same role locally otherwise.
+
 ## What it does
 
 1. **Maps how traffic reaches the process today** — a scout reads the repository, and if there is a


### PR DESCRIPTION
## What changed

- Add a standalone `codex-skills/zero-downtime-deploy` port while leaving the existing Claude plugin untouched.
- Replace Claude-specific `model`, `Task(...)`, custom-agent, and `AskUserQuestion` dependencies with Codex coordination instructions and a local fallback.
- Bundle `infra-scout`, `live-drift-checker`, and `rollback-critic` as read-only role prompts that Codex can delegate to collaboration agents when available.
- Add Codex `agents/openai.yaml` UI metadata and installation documentation.
- Preserve the existing protocol, evidence statuses, production mutation gates, rollback drill, and platform playbooks.
- Clarify two cross-runtime assumptions: use an authoritative platform release record when Git is not the deployment source of truth, and avoid blindly making a shared dependency an all-instance readiness gate.

## Why

Installing only `plugins/zero-downtime-deploy/skills/zero-downtime-deploy` through Codex's skill installer loses the plugin-level custom agents. The skill also references Claude runtime primitives (`Task(...)`, `AskUserQuestion`, `model: fable`) that Codex does not expose in that form.

The separate port keeps Claude marketplace behavior stable and gives Codex a self-contained directory that can be installed directly from GitHub.

## Impact

- Claude Code users see no runtime change.
- Codex users can install the skill globally from `codex-skills/zero-downtime-deploy`.
- The three specialist passes still work with collaboration agents, and degrade to local execution when agent slots are unavailable.

The reference files are intentionally copied into the standalone directory because Codex's GitHub skill installer downloads only the selected subtree.

## Validation

- `quick_validate.py codex-skills/zero-downtime-deploy` → `Skill is valid!`
- Compatibility scan found no remaining Claude runtime markers in the Codex subtree.
- The committed Codex subtree matches the locally installed and validated skill byte-for-byte.
- Repository-only forward test on a real deployment codebase produced the Phase A deployment map, reported repository drift, made no edits or live-system calls, and stopped at the hard gate.
- `git diff --check` passed.
